### PR TITLE
Utilização do userSubject

### DIFF
--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -25,7 +25,9 @@ export class AuthService {
         tap((response: any) => {
           console.log(response);
           localStorage.setItem('token', response.token);
-          this.userSubject.next(response.user);
+          this.getCurrentUser().subscribe((user) =>
+            this.userSubject.next(user)
+          );
         }),
         catchError((error) => {
           console.error('Erro:', error);
@@ -55,6 +57,10 @@ export class AuthService {
   hasRole(role: string): boolean {
     const user = this.userSubject.value;
     return user && user.role === role;
+  }
+
+  getUser(): Observable<any> {
+    return this.userSubject.asObservable();
   }
 
   getCurrentUser(): Observable<any> {

--- a/src/app/professional/professional.service.ts
+++ b/src/app/professional/professional.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { catchError, Observable, switchMap } from 'rxjs';
+import { catchError, Observable, switchMap, throwError } from 'rxjs';
 import { ServiceRequest, ServiceResponse } from '../models/servico.model';
 import { AuthService } from '../auth/auth.service';
 
@@ -17,11 +17,15 @@ export class ProfessionalService {
   }
 
   getProfessionalServices(): Observable<ServiceResponse[]> {
-    return this.authService.getCurrentUser().pipe(
+    return this.authService.getUser().pipe(
       switchMap((pro) => {
-        const proId = pro.id;
-        return this.http.get<any[]>(
-          `${this.apiUrl}servicos/profissional/${proId}`,
+        if (!pro?.id) {
+          return throwError(
+            () => new Error('Usuário não autenticado ou sem ID')
+          );
+        }
+        return this.http.get<ServiceResponse[]>(
+          `${this.apiUrl}servicos/profissional/${pro.id}`,
           {
             headers: {
               'Content-Type': 'application/json',


### PR DESCRIPTION
Utililizar o userSubject é melhor.
Eficiência: getUser() usa userSubject, que armazena os dados do usuário em memória, evitando chamadas HTTP repetidas de getCurrentUser.
Consistência: Atualizar userSubject no login com os dados de getCurrentUser garante que os dados do usuário estejam disponíveis reativamente.
Reatividade: getUser() permite que o componente reaja a mudanças no userSubject (ex.: logout ou atualização de perfil).